### PR TITLE
Quizzes questions past #10 can now have answers added. ref 5191

### DIFF
--- a/nested_admin/static/nesting/nesting.js
+++ b/nested_admin/static/nesting/nesting.js
@@ -1053,7 +1053,7 @@
                     }
                     // Extra check that it is nested (i.e. that there are
                     // two '_set-' strings in the id)
-                    if (!nestedGroupId.substr(0, nestedGroupId.length - 6).match(/\-\d\-/)) {
+                    if (!nestedGroupId.substr(0, nestedGroupId.length - 6).match(/\-\d+\-/)) {
                         return true;
                     }
 


### PR DESCRIPTION
Nested elements past the first ten have a two digit code in their id,
and hence the regex that looks for their number had to select for multiple
digits. Specifically, a typo turned

.match(/-\d+-/)  // Selects multiple digits
into
.match(/-\d-/)   //Selects only one digit
