### PR TITLE
Fix static files URL

### DIFF
--- a/nested_admin/nested.py
+++ b/nested_admin/nested.py
@@ -175,12 +175,12 @@ class NestedAdmin(NestedAdminMixin, ModelAdmin):
             'nesting.js',)
 
         for js_file in js_files:
-            js_file_url = '%s/nesting/%s?v=%d' % (settings.STATIC_URL, js_file, version)
+            js_file_url = '%snesting/%s?v=%d' % (settings.STATIC_URL, js_file, version)
             media.add_js((js_file_url,))
 
         media.add_css({
             'all': (
-                '%s/nesting/nesting.css?v=%d' % (settings.STATIC_URL, version),
+                '%snesting/nesting.css?v=%d' % (settings.STATIC_URL, version),
             )})
         return media
 


### PR DESCRIPTION
Hi,

After following installation instructions on Django 1.8, I get 404 errors for the following static javascript links :

http://127.0.0.1:8000/static//nesting/nesting.css?v=27 
http://127.0.0.1:8000/static//nesting/jquery.ui.sortable.js?v=27 
http://127.0.0.1:8000/static//nesting/nesting.utils.js?v=27 
http://127.0.0.1:8000/static//nesting/nesting.sortable.js?v=27 
http://127.0.0.1:8000/static//nesting/jquery.class.js?v=27 
http://127.0.0.1:8000/static//nesting/jquery.ui.nestedSortable.js?v=27 
http://127.0.0.1:8000/static//nesting/nesting.formset.js?v=27 
http://127.0.0.1:8000/static//nesting/nesting.js?v=27  

The / after STATIC_URL is doubled, resulting in a 404 error. The server says `django.core.exceptions.SuspiciousFileOperation: The joined path (c:\nesting\nesting.js) is located outside of the base path component (c:\windows\system32\src\django-nested-admin\nested_admin\static)`

So most of javascript operations fail, making the admin not very usable. I guess under certain setups, the double slash is ignored, but here under Windows it's not.

Best regards,

Olivier
