### PR TITLE
Partial support for Django v1.10 collapsible inlines.

### DIFF
--- a/nested_admin/templates/nesting/admin/inlines/tabular.html
+++ b/nested_admin/templates/nesting/admin/inlines/tabular.html
@@ -19,7 +19,7 @@
 
     {% ifnogrp %}
     <div class="tabular inline-related">
-    <fieldset class="module">
+    <fieldset class="module {{ inline_admin_formset.classes }}">
     {% endifnogrp %}
 
     <h2 class="collapse-handler grp-collapse-handler">


### PR DESCRIPTION
The dev version of Django has support for collapsible inlines as of this [commit](https://github.com/django/django/commit/5399ccc0f4257676981ef7937ea84be36f7058a6).  Implementing it for tabular inlines was as easy as just adding in {{ inline_admin_formset.classes }} for the fieldset classes. I'm not sure how to add it to stacked inlines as I'm not too familiar with your code.