### PR TITLE
Fix FileFields in deeply nested inlines

### DIFF
--- a/nested_admin/tests/drag_drop.py
+++ b/nested_admin/tests/drag_drop.py
@@ -145,18 +145,11 @@ class DragAndDropAction(object):
         with self.test_case.visible_selector('.ui-sortable-helper') as el:
             return el
 
-    def move_by_offset(self, x_offset, y_offset):
-        increment = -15 if y_offset < 0 else 15
-        for offset in range(0, y_offset, increment):
-            ActionChains(self.selenium).move_by_offset(0, increment).perform()
-        if offset != y_offset:
-            ActionChains(self.selenium).move_by_offset(0, y_offset - offset).perform()
-
     def release(self):
         ActionChains(self.selenium).release().perform()
 
     def _match_helper_with_target(self, helper_element, target_element):
-        self.move_by_offset(0, -1)
+        ActionChains(self.selenium).move_by_offset(0, -16).perform()
 
         desired_pos = tuple(self.to_indexes)
 

--- a/nested_admin/tests/drag_drop.py
+++ b/nested_admin/tests/drag_drop.py
@@ -149,7 +149,7 @@ class DragAndDropAction(object):
         ActionChains(self.selenium).release().perform()
 
     def _match_helper_with_target(self, helper_element, target_element):
-        ActionChains(self.selenium).move_by_offset(0, -16).perform()
+        ActionChains(self.selenium).move_by_offset(0, -15).perform()
 
         desired_pos = tuple(self.to_indexes)
 

--- a/nested_admin/tests/two_deep/models.py
+++ b/nested_admin/tests/two_deep/models.py
@@ -62,6 +62,7 @@ class StackedSection(SectionAbstract):
 
 class StackedItem(ItemAbstract):
     section = ForeignKey(StackedSection, related_name='item_set', on_delete=CASCADE)
+    upload = models.FileField(blank=True, null=True, upload_to='foo')
 
     class Meta:
         ordering = ('section', 'position')


### PR DESCRIPTION
Fixes #111 .

Some highlights:

1. Django 2.1+ implemented `has_file_field`, this value no longer is hardcoded to `True`, but depends on `is_multipart()`. Django relies on `has_file_field` to set form's enctype to multipart.
With false negatives in `has_file_field`, FileField changes are not saved. This commit adds support for nested_formsets to `is_multipart()`.

2. Django 2.1 and 2.2 use Form's `is_multipart` to calculate `has_file_field`. This could be improved, there's already a dedicated FormSet's `is_multipart` which handles a more general case. Django 3 should already use FormSet (see latest master). This PR includes code to handle both scenarios.

3. The variable name `_has_multipart_nested_formset` feels a bit strange; I picked it because it's similar to `has_file_field` and `is_multipart`, I'm open to other suggestions and I can change it if needed.

Updated after forced push:

4. In the early version of this PR the tests used to be in the `tests.two_deep.tests.InlineAdminTestCaseMixin`, this way they were run for both Stacked and Tabular inlines. I've moved them to `TestStackedInlineAdmin` only; TestTabularInlineAdmin test cases were failing due to elements becoming wider and overlapping UI buttons. However, the nesting style doesn't seem to matter in this case.

5. I've added a minor cleanup to the `DragAndDropAction`, more details in commit messages.