### PR TITLE
Add install_requires on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     version="3.2.3",
     install_requires=[
         'python-monkey-business>=1.0.0',
+        'setuptools',
         'six',
     ],
     description="Django admin classes that allow for nested inlines",


### PR DESCRIPTION
pkg_resources is imported at runtime (in \_\_init\_\_.py), so record that dependency. Not doing so causes problems with some packaging schemes, like [pex](https://github.com/pantsbuild/pex) (where the setup and runtime environments are different).