### PR TITLE
Read __version__ from __init__.py

### DIFF
--- a/nested_admin/__init__.py
+++ b/nested_admin/__init__.py
@@ -15,10 +15,7 @@ import django
 import django.forms.formsets
 import monkeybiz
 
-try:
-    __version__ = pkg_resources.get_distribution('django-nested-admin').version
-except pkg_resources.DistributionNotFound:
-    __version__ = None
+__version__ = '3.2.3'
 
 # import mapping to objects in other modules
 all_by_module = {

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import re
+import os.path
 
 try:
     from setuptools import setup, find_packages
@@ -8,9 +10,23 @@ except ImportError:
     from setuptools import setup, find_packages
 
 
+# Find the package version in __init__.py without importing it
+# (which we cannot do because it has extensive dependencies).
+init_file = os.path.join(os.path.dirname(__file__),
+                         'nested_admin', '__init__.py')
+with open(init_file, 'r') as f:
+    for line in f:
+        m = re.search(r'''^__version__ = (['"])(.+?)\1$''', line)
+        if m is not None:
+            version = m.group(2)
+            break
+    else:
+        raise LookupError('Unable to find __version__ in ' + init_file)
+
+
 setup(
     name='django-nested-admin',
-    version="3.2.3",
+    version=version,
     install_requires=[
         'python-monkey-business>=1.0.0',
         'six',


### PR DESCRIPTION
Rather than using setuptools to read the installed package version at runtime. This avoids an undeclared runtime dependency on setuptools which causes problems when using some packaging schemes (like pex).

This is an alternate approach to #149 that prevents the same problem by simply not using setuptools at runtime.