### PR TITLE
Enforce type as tuple

### DIFF
--- a/nested_admin/__init__.py
+++ b/nested_admin/__init__.py
@@ -20,7 +20,7 @@ __version__ = '3.2.3'
 # import mapping to objects in other modules
 all_by_module = {
     'nested_admin.forms': (
-        'SortableHiddenMixin'),
+        'SortableHiddenMixin',),
     'nested_admin.formsets': (
         'NestedInlineFormSet', 'NestedBaseGenericInlineFormSet'),
     'nested_admin.nested': (


### PR DESCRIPTION
Enforce nested_admin.forms becomes a tuple, rather than a string for latest python.

Without a trailing comma, `('SortableHiddenMixin')` becomes `'SortableHiddenMixin'` rather than a tuple containing the string.

This causes problems when `object_origins` loops over it, as it will explode the string into individual characters and loop them, rather than looping the strings in the tuple.

Without:
![image](https://user-images.githubusercontent.com/4339776/62889391-33b81b80-bd39-11e9-869f-4080c071eef2.png)

With:
![image](https://user-images.githubusercontent.com/4339776/62889420-47638200-bd39-11e9-9096-61dee7e7db83.png)

 