### PR TITLE
Fix issue with field-box class changes in django >= 2.1

### DIFF
--- a/nested_admin/templates/nesting/admin/includes/grappelli_inline.html
+++ b/nested_admin/templates/nesting/admin/includes/grappelli_inline.html
@@ -7,7 +7,7 @@
             <div class="form-row djn-row grp-row grp-cells-{{ line.fields|length }}{% if not line.fields|length_is:"1" %} grp-cells{% else %}{% if line.errors %} grp-errors{% endif %}{% endif %}{% if not line.has_visible_field %} grp-row-hidden{% endif %}{% for field in line %} {{ field.field.name }}{% endfor %} ">
                 {% for field in line %}
                     {# <div{% if not line.fields|length_is:"1" %} class="cell {{ field.field.name }}{% if field.errors %} error{% endif %}"{% endif %}> #}
-                    <div class="field-box l-2c-fluid l-d-4{% if line.fields|length_is:"1" %}{% else %} grp-cell{% if field.field.name %} {{ field.field.name }} field-{{ field.field.name }}{% endif %}{% if field.field.errors %} grp-errors{% endif %}{% endif %}">
+                    <div class="field-box fieldBox l-2c-fluid l-d-4{% if line.fields|length_is:"1" %}{% else %} grp-cell{% if field.field.name %} {{ field.field.name }} field-{{ field.field.name }}{% endif %}{% if field.field.errors %} grp-errors{% endif %}{% endif %}">
                         {% if field.is_checkbox %}
                             <div class="c-1">&nbsp;</div>
                             <div class="c-2">

--- a/nested_admin/templates/nesting/admin/includes/inline.html
+++ b/nested_admin/templates/nesting/admin/includes/inline.html
@@ -8,7 +8,7 @@
         <div class="form-row{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}{% if forloop.last and forloop.parentloop.last %} djn-form-row-last{% endif %}">
             {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
             {% for field in line %}
-                <div class="{% if line.fields|length_is:'1' and field.is_checkbox %}checkbox-row{% else %}{% if not line.fields|length_is:'1' %}field-box{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %} {% endif %}field-{{ field.field.name }}{% endif %}">
+                <div class="{% if line.fields|length_is:'1' and field.is_checkbox %}checkbox-row{% else %}{% if not line.fields|length_is:'1' %}field-box fieldBox{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %} {% endif %}field-{{ field.field.name }}{% endif %}">
                     {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.errors }}{% endif %}
                     {% if field.is_checkbox %}
                         {{ field.field }}{{ field.label_tag }}

--- a/nested_admin/templates/nesting/admin/includes/suit_inline.html
+++ b/nested_admin/templates/nesting/admin/includes/suit_inline.html
@@ -15,7 +15,7 @@
         {# write special control tags only for first multi field #}
         {% if forloop.first %}
             <div{% if not singlefield %}
-                class="field-box{% if field.field.name %} field-{{ field.field.name }}{% endif %}"{% endif %}>
+                class="field-box fieldBox{% if field.field.name %} field-{{ field.field.name }}{% endif %}"{% endif %}>
 
             <div class="control-label">
                 {{ field.label_tag }}


### PR DESCRIPTION
In Django 2.1, the field-box class has been renamed to fieldBox. So when I put fields on a line using fieldsets, it was originally displayed as one line, but when I upgraded my version of Django, it appears as multiple lines. Since it should be compatible with older django versions, I modified it to show two classes at the same time.

Related:
* Django 2.1 Release Note: https://docs.djangoproject.com/en/3.0/releases/2.1/#miscellaneous (The admin CSS class field-box is renamed to fieldBox to prevent conflicts with the class given to model fields named “box”.)
* Fixed #29248 -- Renamed admin CSS class field-box to fieldBox.  https://code.djangoproject.com/ticket/29248
* Commit: https://github.com/django/django/commit/5d4d62bf4fe887fcd30f9f0449de07ae76ea5968