### PR TITLE
Handle subclasses of PolymorphicModel being abstract

### DIFF
--- a/nested_admin/polymorphic.py
+++ b/nested_admin/polymorphic.py
@@ -79,10 +79,10 @@ class NestedPolymorphicInlineAdminFormset(
             formset_fk_model = ''
             parent_models = []
         compatible_parents = get_compatible_parents(self.formset.model)
-        sub_models = self.formset.model()._get_inheritance_relation_fields_and_models()
+        sub_models = get_child_polymorphic_models(self.formset.model)
         data['nestedOptions'].update({
             'parentModel': get_model_id(formset_fk_model),
-            'childModels': [get_model_id(m) for m in sub_models.values()],
+            'childModels': [get_model_id(m) for m in sub_models],
             'parentModels': [get_model_id(m) for m in parent_models],
             'compatibleParents': {
                 get_model_id(k): [get_model_id(m) for m in v]

--- a/nested_admin/tests/nested_polymorphic/test_polymorphic_abstract_classes/admin.py
+++ b/nested_admin/tests/nested_polymorphic/test_polymorphic_abstract_classes/admin.py
@@ -1,0 +1,44 @@
+from django.contrib import admin
+from django.db import models
+from django import forms
+
+import nested_admin
+
+from .models import (
+    FreeTextBlock, PollBlock, QuestionBlock, Survey, SurveyBlock, )
+
+
+class SurveyBlockInline(nested_admin.NestedStackedPolymorphicInline):
+    class QuestionInline(nested_admin.NestedStackedPolymorphicInline.Child):
+        model = QuestionBlock
+        sortable_field_name = "position"
+        formfield_overrides = {
+            models.PositiveSmallIntegerField: {'widget': forms.HiddenInput},
+        }
+
+    class FreeTextInline(nested_admin.NestedStackedPolymorphicInline.Child):
+        model = FreeTextBlock
+        sortable_field_name = "position"
+        formfield_overrides = {
+            models.PositiveSmallIntegerField: {'widget': forms.HiddenInput},
+        }
+
+    class PollInline(nested_admin.NestedStackedPolymorphicInline.Child):
+        model = PollBlock
+        sortable_field_name = "position"
+        formfield_overrides = {
+            models.PositiveSmallIntegerField: {'widget': forms.HiddenInput},
+        }
+
+    model = SurveyBlock
+    extra = 0
+    sortable_field_name = "position"
+    child_inlines = (FreeTextInline, PollInline, QuestionInline)
+    formfield_overrides = {
+        models.PositiveSmallIntegerField: {'widget': forms.HiddenInput},
+    }
+
+
+@admin.register(Survey)
+class SurveyAdmin(nested_admin.NestedPolymorphicModelAdmin):
+    inlines = (SurveyBlockInline,)

--- a/nested_admin/tests/nested_polymorphic/test_polymorphic_abstract_classes/models.py
+++ b/nested_admin/tests/nested_polymorphic/test_polymorphic_abstract_classes/models.py
@@ -1,0 +1,47 @@
+import django
+from django.db import models
+from django.db.models import ForeignKey, CASCADE
+
+try:
+    from polymorphic.models import PolymorphicModel
+except:
+    # Temporary until django-polymorphic supports django 3.1
+    if django.VERSION < (3, 1):
+        raise
+    else:
+        PolymorphicModel = models.Model
+
+
+def NON_POLYMORPHIC_CASCADE(collector, field, sub_objs, using):
+    return CASCADE(collector, field, sub_objs.non_polymorphic(), using)
+
+
+class Survey(models.Model):
+    title = models.CharField(max_length=255)
+
+
+class SurveyBlock(PolymorphicModel):
+    survey = ForeignKey(Survey, related_name='blocks', on_delete=NON_POLYMORPHIC_CASCADE)
+    position = models.PositiveSmallIntegerField(null=True)
+
+    class Meta:
+        ordering = ["position"]
+
+
+class BaseQuestionBlock(SurveyBlock):
+    label = models.CharField(max_length=255)
+
+    class Meta:
+        abstract = True
+
+
+class QuestionBlock(BaseQuestionBlock):
+    is_required = models.BooleanField()
+
+
+class FreeTextBlock(BaseQuestionBlock):
+    pass
+
+
+class PollBlock(BaseQuestionBlock):
+    pass

--- a/nested_admin/tests/nested_polymorphic/test_polymorphic_abstract_classes/tests.py
+++ b/nested_admin/tests/nested_polymorphic/test_polymorphic_abstract_classes/tests.py
@@ -1,0 +1,76 @@
+from unittest import SkipTest
+from django.test import TestCase
+
+from .models import (
+    FreeTextBlock, PollBlock, QuestionBlock, Survey, SurveyBlock, )
+
+
+try:
+    from nested_admin.tests.nested_polymorphic.base import BaseNestedPolymorphicTestCase
+except ImportError:
+    BaseNestedPolymorphicTestCase = TestCase
+    has_polymorphic = False
+else:
+    has_polymorphic = True
+
+
+class PolymorphicAbstractClassesTestCase(BaseNestedPolymorphicTestCase):
+    root_model = Survey
+    nested_models = (SurveyBlock, )
+
+    @classmethod
+    def setUpClass(cls):
+        if not has_polymorphic:
+            raise SkipTest('django-polymorphic unavailable')
+        super(PolymorphicAbstractClassesTestCase, cls).setUpClass()
+
+    def test_add_level_one_to_empty(self):
+        obj = self.root_model.objects.create(title='test')
+        self.load_admin(obj)
+        self.add_inline(model=QuestionBlock, label='x')
+        self.save_form()
+
+        blocks = obj.blocks.all()
+        self.assertEqual(len(blocks), 1)
+        self.assertIsInstance(blocks[0], QuestionBlock)
+        self.assertEqual(blocks[0].label, 'x')
+        self.assertEqual(blocks[0].is_required, False)
+
+    def test_can_move_children_of_abstract(self):
+        obj = self.root_model.objects.create(title='test')
+        self.load_admin(obj)
+        self.add_inline(model=PollBlock, label='poll')
+        self.add_inline(model=QuestionBlock, label='question')
+        self.add_inline(model=FreeTextBlock, label='free')
+        self.save_form()
+
+        blocks = obj.blocks.all()
+        self.assertEqual(len(blocks), 3)
+        self.assertIsInstance(blocks[0], PollBlock)
+        self.assertEqual(blocks[0].label, 'poll')
+        self.assertEqual(blocks[0].position, 0)
+        self.assertIsInstance(blocks[1], QuestionBlock)
+        self.assertEqual(blocks[1].label, 'question')
+        self.assertEqual(blocks[1].position, 1)
+        self.assertEqual(blocks[1].is_required, False)
+        self.assertIsInstance(blocks[2], FreeTextBlock)
+        self.assertEqual(blocks[2].label, 'free')
+        self.assertEqual(blocks[2].position, 2)
+
+        # Move question block to top
+        self.drag_and_drop_item([1], [0], screenshot_hack=True)
+
+        self.save_form()
+
+        blocks = obj.blocks.all()
+        self.assertEqual(len(blocks), 3)
+        self.assertIsInstance(blocks[0], QuestionBlock)
+        self.assertEqual(blocks[0].label, 'question')
+        self.assertEqual(blocks[0].position, 0)
+        self.assertEqual(blocks[0].is_required, False)
+        self.assertIsInstance(blocks[1], PollBlock)
+        self.assertEqual(blocks[1].label, 'poll')
+        self.assertEqual(blocks[1].position, 1)
+        self.assertIsInstance(blocks[2], FreeTextBlock)
+        self.assertEqual(blocks[2].label, 'free')
+        self.assertEqual(blocks[2].position, 2)


### PR DESCRIPTION
When there was an abstract model in between a concrete subclass and it's `PolymorphicModel` class, the admin would not allow the child model to be moved because it was not in the allowed "childModels" being passed to the frontend.

For example the following would break:

```mermaid
graph TD;
  A[PolymorphicModel];
  A --> B[AbstractBase];
  B --> C[ChildOfAbstract];
  B --> D[ChildOfAbstract2];
  A --> E[DirectPolymorphicChild];
```

Before, the only valid child models passed to the frontend would be `DirectPolymorphicChild` and `AbstractBase`. This meant that `ChildOfAbstract` and `ChildOfAbstract2` could be added to the admin, but were blocked from being moved around.

Added a test app to verify this change and show that now having an abstract class doesn't break the admin.