### PR TITLE
fix(templates): Remove use of deprecated filter

### DIFF
--- a/nested_admin/templates/nesting/admin/includes/grappelli_inline.html
+++ b/nested_admin/templates/nesting/admin/includes/grappelli_inline.html
@@ -4,10 +4,10 @@
         {% if fieldset.name %}<h4 class="djn-collapse-handler grp-collapse-handler">{{ fieldset.name }}</h4>{% endif %}
         {% if fieldset.description %}<div class="grp-row"><p class="grp-description">{{ fieldset.description|safe }}</p></div>{% endif %}
         {% for line in fieldset %}
-            <div class="form-row djn-row grp-row grp-cells-{{ line.fields|length }}{% if not line.fields|length_is:"1" %} grp-cells{% else %}{% if line.errors %} grp-errors{% endif %}{% for field in line %} {{ field.field.name }} field-{{ field.field.name }}{% endfor %}{% endif %}{% if not line.has_visible_field %} grp-row-hidden{% endif %}">
+            <div class="form-row djn-row grp-row grp-cells-{{ line.fields|length }}{% if not line.fields|length == 1 %} grp-cells{% else %}{% if line.errors %} grp-errors{% endif %}{% for field in line %} {{ field.field.name }} field-{{ field.field.name }}{% endfor %}{% endif %}{% if not line.has_visible_field %} grp-row-hidden{% endif %}">
                 {% for field in line %}
-                    {# <div{% if not line.fields|length_is:"1" %} class="cell {{ field.field.name }}{% if field.errors %} error{% endif %}"{% endif %}> #}
-                    <div class="field-box l-2c-fluid l-d-4{% if line.fields|length_is:"1" %}{% else %} grp-cell{% if field.field.name %} {{ field.field.name }} field-{{ field.field.name }}{% endif %}{% if field.field.errors %} grp-errors{% endif %}{% endif %}">
+                    {# <div{% if not line.fields|length == 1 %} class="cell {{ field.field.name }}{% if field.errors %} error{% endif %}"{% endif %}> #}
+                    <div class="field-box l-2c-fluid l-d-4{% if line.fields|length == 1 %}{% else %} grp-cell{% if field.field.name %} {{ field.field.name }} field-{{ field.field.name }}{% endif %}{% if field.field.errors %} grp-errors{% endif %}{% endif %}">
                         {% if field.is_checkbox %}
                             <div class="c-1">&nbsp;</div>
                             <div class="c-2">
@@ -21,8 +21,8 @@
                                     {{ field.field }}
                                 {% endif %}
                         {% endif %}
-                            {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
-                            {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.errors }}{% endif %}
+                            {% if line.fields|length == 1 %}{{ line.errors }}{% endif %}
+                            {% if not line.fields|length == 1 and not field.is_readonly %}{{ field.errors }}{% endif %}
                             {% if field.field.field.help_text %}
                                 <p class="grp-help">{{ field.field.field.help_text|safe }}</p>
                             {% endif %}

--- a/nested_admin/templates/nesting/admin/includes/inline.html
+++ b/nested_admin/templates/nesting/admin/includes/inline.html
@@ -4,11 +4,11 @@
         <div class="description">{{ fieldset.description|safe }}</div>
     {% endif %}
     {% for line in fieldset %}
-        <div class="form-row{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}{% if forloop.last and forloop.parentloop.last %} djn-form-row-last{% endif %}">
-            {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
+        <div class="form-row{% if line.fields|length == 1 and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}{% if forloop.last and forloop.parentloop.last %} djn-form-row-last{% endif %}">
+            {% if line.fields|length == 1 %}{{ line.errors }}{% endif %}
             {% for field in line %}
-                <div class="{% if line.fields|length_is:'1' and field.is_checkbox %}checkbox-row{% else %}{% if not line.fields|length_is:'1' %}fieldBox{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %} {% endif %}field-{{ field.field.name }}{% endif %}">
-                    {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.errors }}{% endif %}
+                <div class="{% if line.fields|length == 1 and field.is_checkbox %}checkbox-row{% else %}{% if not line.fields|length == 1 %}fieldBox{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %} {% endif %}field-{{ field.field.name }}{% endif %}">
+                    {% if not line.fields|length == 1 and not field.is_readonly %}{{ field.errors }}{% endif %}
                     {% if field.is_checkbox %}
                         {{ field.field }}{{ field.label_tag }}
                     {% else %}


### PR DESCRIPTION
The length_is filter has been deprecated in favour of using the length filter with an equality operator.

Resolves #236 