### PR TITLE
Declare pytest selenium marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,7 @@
 DJANGO_SETTINGS_MODULE = nested_admin.tests.settings
 addopts = --tb=short --create-db --cov=nested_admin
 django_find_project = false
+markers =
+    selenium
 python_files = tests.py test_*.py *_tests.py
 testpaths = nested_admin/tests


### PR DESCRIPTION
Fix this warning seen in the test run:

```
/.../site-packages/_pytest/nodes.py:356: PytestUnknownMarkWarning: Unknown pytest.mark.selenium - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
  marker_ = getattr(MARK_GEN, marker)
```

Following [the linked docs page](https://docs.pytest.org/en/stable/how-to/mark.html).
