### PR TITLE
Include conditional styling when using Jazzmin Template

### DIFF
--- a/nested_admin/nested.py
+++ b/nested_admin/nested.py
@@ -512,6 +512,8 @@ class NestedInlineModelAdminMixin:
 
     if "grappelli" in settings.INSTALLED_APPS:
         fieldset_template = "nesting/admin/includes/grappelli_inline.html"
+    elif "jazzmin" in settings.INSTALLED_APPS:
+        fieldset_template = "nesting/admin/includes/jazzmin_inline.html"
     else:
         fieldset_template = "nesting/admin/includes/inline.html"
 
@@ -561,6 +563,8 @@ class NestedStackedInlineMixin(NestedInlineModelAdminMixin):
 
     if "grappelli" in settings.INSTALLED_APPS:
         template = "nesting/admin/inlines/grappelli_stacked.html"
+    elif "jazzmin" in settings.INSTALLED_APPS:
+        template = "nesting/admin/inlines/jazzmin_stacked.html"
     else:
         template = "nesting/admin/inlines/stacked.html"
 
@@ -597,6 +601,8 @@ class NestedGenericStackedInlineMixin(NestedGenericInlineModelAdminMixin):
 
     if "grappelli" in settings.INSTALLED_APPS:
         template = "nesting/admin/inlines/grappelli_stacked.html"
+    elif "jazzmin" in settings.INSTALLED_APPS:
+        template = "nesting/admin/inlines/jazzmin_stacked.html"
     else:
         template = "nesting/admin/inlines/stacked.html"
 

--- a/nested_admin/templates/nesting/admin/includes/jazzmin_inline.html
+++ b/nested_admin/templates/nesting/admin/includes/jazzmin_inline.html
@@ -1,0 +1,41 @@
+<fieldset class="mt-3 mx-2 module aligned djn-module {{ fieldset.classes }}{% if inline_admin_form.form.inlines %} has-inlines{% endif %}">
+    {% if fieldset.name %}
+    <h2>{{ fieldset.name }}</h2>
+    <div class="card-header">
+        <div class="card-title">
+            <strong>{{ fieldset.name }}</strong>{% if fieldset.description %} - <i>{{ fieldset.description|safe }}</i>{% endif %}
+        </div>
+    </div>
+    {% endif %}
+    {% for line in fieldset %}
+    <div class="form-group{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}{% if forloop.last and forloop.parentloop.last %} djn-form-row-last{% endif %}">
+        <div class="row">
+            {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
+            {% for field in line %}
+            <label class="{% if not line.fields|length_is:'1' and forloop.counter != 1 %}col-auto {% else %}col-sm-3 {% endif %}text-left" for="id_{{ field.field.name }}">
+                {{ field.field.label|capfirst }}
+                {% if field.field.field.required %}
+                <span class="text-red">* </span>
+                {% endif %}
+            </label>
+            <div class="{% if not line.fields|length_is:'1' %} col-auto fieldBox {% else %} col-sm-9 {% endif %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden {% endif %}{% if field.is_checkcard %} checkcard-row{% endif %}">
+                {% if field.is_readonly %}
+                <div class="readonly">{{ field.contents }}</div>
+                {% else %}
+                {{ field.field }}
+                {% endif %}
+                <div class="help-block red">
+                    {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.errors }}{% endif %}
+                </div>
+                {% if field.field.help_text %}
+                <div class="help-block">{{ field.field.help_text|safe }}</div>
+                {% endif %}
+                <div class="help-block text-red">
+                    {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endfor %}
+</fieldset>

--- a/nested_admin/templates/nesting/admin/inlines/jazzmin_stacked.html
+++ b/nested_admin/templates/nesting/admin/inlines/jazzmin_stacked.html
@@ -1,0 +1,95 @@
+{% load i18n nested_admin admin_urls %}
+{% with inline_admin_formset.formset.is_nested as is_nested %}
+
+{% with inline_admin_formset.opts as inline_opts %}
+<div class="group djn-group djn-stacked{% if is_nested %} djn-group-nested{% else %} djn-group-root{% endif %}"
+    id="{{ inline_admin_formset.formset.prefix }}-group"
+    data-inline-type="stacked"
+    data-inline-formset="{{ inline_admin_formset.inline_formset_data }}"
+    data-inline-model="{{ inline_admin_formset.inline_model_id }}">
+
+    {% ifinlineclasses %}<fieldset class="djn-fieldset module card {{ inline_admin_formset.classes }}">{% endifinlineclasses %}
+
+        <div class="card-header">
+            <h2 class="card-title">
+                {% if inline_admin_formset.opts.title %}{{ inline_admin_formset.opts.title }}{% else %}{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}{% endif %}
+            </h2>
+        </div>
+
+
+    {{ inline_admin_formset.formset.management_form }}
+    {{ inline_admin_formset.formset.non_form_errors }}
+        <div>
+            <div class="items djn-items">
+                {% with inline_admin_formset.opts.sortable_field_name|default:"" as sortable_field_name %}
+                {% for inline_admin_form in inline_admin_formset|formsetsort:sortable_field_name %}
+                    {% if forloop.first %}
+                    <div class="djn-item djn-no-drag"><div></div></div>
+                    {% endif %}
+                    <div >
+                        <div class="{% if not forloop.last or not inline_admin_formset.has_add_permission %}djn-item{% endif %} djn-module djn-inline-form{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} djn-empty-form empty-form last-related{% endif %}"
+                            data-inline-model="{{ inline_admin_form.model_admin.opts.app_label }}-{{ inline_admin_form.model_admin.opts.model_name }}"
+                            {% if inline_admin_form.pk_field.field %}
+                            data-is-initial="{% if inline_admin_form.pk_field.field.value %}true{% else %}false{% endif %}"
+                            {% endif %}
+                            id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ inline_admin_form.form|form_index }}{% endif %}">
+                        <div class="card-header">
+                            <h3 class="w-100 card-title mb-0 d-flex justify-content-between align-items-center{% if not inline_opts.sortable_options or not inline_opts.sortable_options.disabled %} djn-drag-handler{% endif %}">
+                                <b>{{ inline_admin_formset.opts.verbose_name|capfirst }}:</b>
+
+                                <span class="inline_label">
+                                    {% if inline_admin_form.original %}{{ inline_admin_form.original }}
+                                    {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %} <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{% if inline_admin_formset.has_change_permission %}inlinechangelink{% else %}inlineviewlink{% endif %}">{% if inline_admin_formset.has_change_permission %}{% trans "Change" %}{% else %}{% trans "View" %}{% endif %}</a>{% endif %}
+                                    {% else %}#{{ forloop.counter }}{% endif %}
+                                </span>
+
+                                {% if inline_admin_form.show_url %}
+                                <a href="{{ inline_admin_form.absolute_url }}">{% trans "View on site" %}</a>
+                                {% endif %}
+                                <div class="d-flex flex-column align-items-center">
+                                {% if inline_admin_formset.formset.can_delete  %}
+                                    {% if inline_admin_form.original %}
+                                        <span class="delete djn-delete-handler {{ inline_admin_formset.handler_classes|join:" " }}">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</span>
+                                    {% else %}
+                                        <span ><a class="inline-deletelink djn-remove-handler {{ inline_admin_formset.handler_classes|join:" " }}" href="javascript:void(0)">{% trans "Delete" %}</a></span>
+                                    {% endif %}
+                                {% endif %}
+                                </div>
+                            </h3>
+                        </div>
+                        {% if inline_admin_form.form.non_field_errors %}
+                            <ul class="errorlist">
+                                <li>{{ inline_admin_form.form.non_field_errors }}</li>
+                            </ul>
+                        {% endif %}
+
+                        {% for fieldset in inline_admin_form %}
+                            {% include inline_admin_formset.opts.fieldset_template %}
+                        {% endfor %}
+                        {% if inline_admin_form.has_auto_field or inline_admin_form.needs_explicit_pk_field %}
+                            {{ inline_admin_form.pk_field.field }}
+                        {% endif %}
+                        {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
+                        {% if inline_admin_form.form.inlines %}
+                            {% for nested in inline_admin_form.form.inlines %}
+                                {% include nested.opts.template with inline_admin_formset=nested %}
+                            {% endfor %}
+                        {% endif %}
+                        </div>
+                    </div>
+                {% endfor %}
+                {% endwith %}
+            </div>
+        </div>
+   <div class="card-footer">
+       <div class="djn-module djn-add-item add-item add-row">
+           <a href="javascript://" class="add-handler djn-add-handler btn btn-info {{ inline_admin_formset.handler_classes|join:" " }}">
+               {% blocktrans with inline_admin_formset.opts.verbose_name|strip_parent_name:inline_opts.verbose_name|title as verbose_name %}Add another {{ verbose_name }}{% endblocktrans %}
+           </a>
+       </div>
+   </div>
+    {% ifinlineclasses %}</fieldset>{% endifinlineclasses %}
+</div>
+{% endwith %}
+
+{% endwith %}


### PR DESCRIPTION
Some enhancements for Jazzmin admin template styling.
- Beautiful styling using bootstrap cards.
- Fixing internationalization.
- Only modified for NestedStackedInline, if this pull request pass, I will adapt NestedTabularInline and make some enhancements. 

![Captura de pantalla 2024-04-11 161044](https://github.com/theatlantic/django-nested-admin/assets/55591455/0d9dcccb-2b3d-4c5c-9b89-2d4551cb3549)

![Captura de pantalla 2024-04-11 161100](https://github.com/theatlantic/django-nested-admin/assets/55591455/dda0d208-466b-486d-bcca-1bea3f43bf0f)

![Captura de pantalla 2024-04-11 161116](https://github.com/theatlantic/django-nested-admin/assets/55591455/d1c7f25f-b3a8-46d6-ba73-da82d285a783)
