### PR TITLE
Fixed: Correctly show heading in tabular template

### DIFF
--- a/nested_admin/templates/nesting/admin/inlines/tabular.html
+++ b/nested_admin/templates/nesting/admin/inlines/tabular.html
@@ -13,7 +13,7 @@
     <fieldset class="module djn-fieldset {{ inline_admin_formset.classes }}" aria-labelledby="{{ inline_admin_formset.formset.prefix }}-heading">
     {% if inline_admin_formset.is_collapsible %}<details><summary>{% endif %}
 
-    <h2 id="{{ inline_admin_formset.formset.prefix }}-heading" class="inline-heading"></h2>
+    <h2 id="{{ inline_admin_formset.formset.prefix }}-heading" class="inline-heading">
         {% if inline_admin_formset.opts.title %}{{ inline_admin_formset.opts.title }}{% else %}{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}{% endif %}
     </h2>
     {% if inline_admin_formset.is_collapsible %}</summary>{% endif %}


### PR DESCRIPTION
Fixes #261 

There seems to be a small markup error in the tabular template: The `h2` heading element is closed twice, causing the heading content to be shown outside of the heading element, looking like `span`-ish text with regards to styling. See also the screenshots below:

## Current situation

<img width="865" alt="image" src="https://github.com/user-attachments/assets/dcdadc74-13b1-4cd2-b05a-9174bd0ef6ff">

## Situation after fix

This PR then removes the first `h2` closing tag so that the title will have the correct position and styling.

<img width="1223" alt="image" src="https://github.com/user-attachments/assets/98bef336-c45c-4522-a51f-ea4b0fffa0db">

