### PR TITLE
Fixed sortable tabular inline visualization bug for view-only users

### DIFF
--- a/nested_admin/templates/nesting/admin/inlines/tabular.html
+++ b/nested_admin/templates/nesting/admin/inlines/tabular.html
@@ -71,7 +71,13 @@
                 {% for fieldset in inline_admin_form %}
                     {% for line in fieldset %}
                         {% for field in line %}
-                            {% if field.field.is_hidden %} {{ field.field }} {% endif %}
+                            {% if field.field.is_hidden %}
+                                {% if field.is_readonly %}
+                                    {{ field.form|get_field_instance:field.field.name }}
+                                {% else %}
+                                    {{ field.field }}
+                                {% endif %}
+                            {% endif %}
                         {% endfor %}
                     {% endfor %}
                 {% endfor %}

--- a/nested_admin/templatetags/nested_admin.py
+++ b/nested_admin/templatetags/nested_admin.py
@@ -179,6 +179,11 @@ def django_version_gte(string):
     return django_version >= str_to_version(string)
 
 
+@register.filter
+def get_field_instance(fields_container, field_label):
+    return fields_container.__getitem__(field_label)
+
+
 @register.tag
 def ifinlineclasses(parser, token):
     nodelist_true = parser.parse(("else", "endifinlineclasses"))


### PR DESCRIPTION
Code:

```python
import nested_admin

from django.db import models
from django.contrib import admin


class Menu(models.Model):
    name = models.TextField(max_length=64)


class Dish(models.Model):
    class Meta:
        ordering = ['position']
        verbose_name_plural = 'Dishes'

    name = models.TextField(max_length=64)

    menu = models.ForeignKey(Menu, models.CASCADE)

    position = models.PositiveIntegerField(
        default=0,
        blank=False,
        null=False,
    )


class DishNestedTabularInline(nested_admin.SortableHiddenMixin, nested_admin.NestedTabularInline):
    model = Dish
    extra = 0


class MenuAdmin(nested_admin.NestedModelAdmin):
    inlines = [DishNestedTabularInline]


admin.site.register(Dish)
admin.site.register(Menu, MenuAdmin)
```


The admin page for the Menu model has the following appearance:

![image](https://github.com/user-attachments/assets/cd863f21-f6d0-4205-93d8-5074c56817bc)

For an user without change permissions, however, the form will look rather different:

![image](https://github.com/user-attachments/assets/55cc4e91-60e9-438f-a654-1eacd8ad744f)

A quick inspection of the HTML reveals the problem. The field responsible for ordering the inlines, which is normally represented as an input element, is being rendered as a dictionary instead. 

![image](https://github.com/user-attachments/assets/c6537815-5d67-45b6-b4b6-2ee8e15c87eb)

![image](https://github.com/user-attachments/assets/c8e043e1-c1ee-46bc-81aa-52aa713c851d)

These two elements are added to the HTML by the following line:

```HTML
{% if field.field.is_hidden %} {{ field.field }} {% endif %}
```

where field is an instance of either AdminField or AdminReadonlyField. These two classes are also the root of the problem, their __init__ mehtod, specifically:

```python
...
class AdminField:
    def __init__(self, form, field, is_first):
        self.field = form[field]  # A django.forms.BoundField instance
        self.is_first = is_first  # Whether this field is first on the line
        self.is_checkbox = isinstance(self.field.field.widget, forms.CheckboxInput)
        self.is_readonly = False

...

class AdminReadonlyField:
    def __init__(self, form, field, is_first, model_admin=None):
        ...
        self.field = {
            "name": class_name,
            "label": label,
            "help_text": help_text,
            "field": field,
            "is_hidden": is_hidden,
        }
        self.form = form

...
```

The difference is therefore located here. For view-only users, self.field corresponds to a simple dictionary, which does not contain any HTML. For users with more permissions, on the other hand, self.field will correspond to a BoundField, which will eventually return the expected HTML element.

In my implementation I tried to do the exact same thing that the __init__ method does, aka accessing the form dictionary to retrieve a BoundField instance. This can be done quite easily by accessing field.form instead of field.field and then using a filter to retrieve the required Object.