### PR TITLE
fix: correct field help text layout on Django 5.2

### DIFF
--- a/nested_admin/templates/nesting/admin/includes/inline.html
+++ b/nested_admin/templates/nesting/admin/includes/inline.html
@@ -27,6 +27,7 @@
                             {{ field.field }}
                         {% endif %}
                     {% endif %}
+                    {% if "5.0"|django_version_gte %}</div>{% endif %}
                     {% if field.field.help_text %}
                         <div class="help{% if field.field.is_hidden %} hidden{% endif %}"{% if field.field.id_for_label %} id="{{ field.field.id_for_label }}_helptext"{% endif %}>
                             {% if "5.0"|django_version_lt %}
@@ -36,7 +37,6 @@
                             {% endif %}
                         </div>
                     {% endif %}
-                    {% if "5.0"|django_version_gte %}</div>{% endif %}
                 </div>
             {% endfor %}
             {% if "5.0"|django_version_gte and not line.fields|length == 1 %}</div>{% endif %}


### PR DESCRIPTION
After commit 7537fcb556fa473d68d054df735109909311dcb1, field help text in Django 5.2 were rendered inside the flexbox container, causing it to appear on the same line as the field. This broke Django’s default layout convention, where help text is displayed below the field.

This patch moves the help text outside the flexbox container, restoring the expected layout.

