### PR TITLE
Fix compatibility with django-polymorphic 4.6

### DIFF
--- a/nested_admin/polymorphic.py
+++ b/nested_admin/polymorphic.py
@@ -50,7 +50,7 @@ def get_child_polymorphic_models(model):
 
 
 def get_polymorphic_related_models(model):
-    return model()._get_inheritance_relation_fields_and_models().values()
+    return model._meta.parents.keys()
 
 
 def get_compatible_parents(model):


### PR DESCRIPTION
 Replaces private `_get_inheritance_relation_fields_and_models()` API with
  Django's public `model._meta.parents.keys()`.

  ## Context
  django-polymorphic 4.6 removed/changed the private method this code depended on.
  See: https://github.com/jazzband/django-polymorphic/compare/v4.5.1...v4.6.0

  Related issue: #278 